### PR TITLE
[_]: fix(checkout): let the payment fail

### DIFF
--- a/src/webhooks/handleCheckoutSessionCompleted.ts
+++ b/src/webhooks/handleCheckoutSessionCompleted.ts
@@ -54,7 +54,8 @@ export default async function handleCheckoutSessionCompleted(
       `Error while creating or updating user in checkout session completed handler, email: ${session.customer_email}`,
     );
     log.error(err);
-    return;
+    
+    throw err;
   }
 
   try {


### PR DESCRIPTION
Throws an error instead of returning when the user creation/update fails, forcing the caller to handle that error (usually returning a 500 HTTP status code)