### PR TITLE
Handle async checkout event for SEPA payments

### DIFF
--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -76,6 +76,16 @@ export default function (
             config,
           );
           break;
+        case 'checkout.session.async_payment_succeeded':
+          await handleCheckoutSessionCompleted(
+            event.data.object as Stripe.Checkout.Session,
+            usersService,
+            paymentService,
+            fastify.log,
+            cacheService,
+            config,
+          );
+          break;
         case 'charge.refunded':
           await handleLifetimeRefunded(
             storageService,


### PR DESCRIPTION
Since SEPA payments are identified by an async checkout session we need to start handling this event (already activated from the Stripe dashboard).

