### PR TITLE
[_] fix: add missing payment service mock

### DIFF
--- a/tests/src/controller.test.ts
+++ b/tests/src/controller.test.ts
@@ -1,6 +1,7 @@
 import Stripe from 'stripe';
 import { buildApp } from '../../src/app';
 import { AppConfig } from '../../src/config';
+import { UserSubscription } from '../../src/core/users/User';
 import CacheService from '../../src/services/CacheService';
 import { PaymentService } from '../../src/services/PaymentService';
 import { StorageService } from '../../src/services/StorageService';
@@ -301,7 +302,12 @@ describe('controller e2e tests', () => {
         return {} as Stripe.Subscription;
       };
 
+      paymentsService.getUserSubscription = async (customerId: string) => {
+        return Promise.resolve({} as UserSubscription);
+      };
+
       const fn = jest.spyOn(paymentsService, 'updateSubscriptionPrice');
+      const getUserSubscriptionSpy = jest.spyOn(paymentsService, 'getUserSubscription');
 
       const response = await app.inject({
         method: 'PUT',
@@ -311,6 +317,7 @@ describe('controller e2e tests', () => {
       });
 
       expect(fn).toBeCalledWith('customerId', 'price_id');
+      expect(getUserSubscriptionSpy).toBeCalledWith('customerId');
 
       expect(response.statusCode).toBe(200);
     });


### PR DESCRIPTION
The test: `controller e2e tests 👉🏼 PUT /subscriptions 👉🏼 happy path` was failing due to `getUserSubscription` not being declarated:
```json
{
  "req": {
    "method": "PUT",
    "url": "/subscriptions",
    "hostname": "localhost:80",
    "remoteAddress": "127.0.0.1"
  },
  "res": {
    "statusCode": 500
  },
  "err": {
    "type": "TypeError",
    "message": "paymentService.getUserSubscription` is not a function",
    "stack": "TypeError: paymentService.getUserSubscription is not a function\n    at Object.<anonymous> (/home/joan/internxt/payments/src/controller.ts:98:58)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)"
  },
  "msg": "paymentService.getUserSubscription is not a function"
}
```