### PR TITLE
Allow promotion codes

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -185,7 +185,7 @@ export class PaymentService {
       line_items: [{ price: priceId, quantity: 1 }],
       mode,
       discounts: couponCode ? [{ coupon: couponCode }] : undefined,
-      allow_promotion_codes: couponCode ? undefined : true,
+      allow_promotion_codes: true,
       billing_address_collection: 'required',
     });
   }


### PR DESCRIPTION
Allows using promotion codes upon checkout. 

Docs: https://stripe.com/docs/payments/checkout/discounts#promotion-codes