### PR TITLE
[_]: fix/allow-coupons

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -185,7 +185,7 @@ export class PaymentService {
       line_items: [{ price: priceId, quantity: 1 }],
       mode,
       discounts: couponCode ? [{ coupon: couponCode }] : undefined,
-      allow_promotion_codes: true,
+      allow_promotion_codes: couponCode ? undefined : true,
       billing_address_collection: 'required',
     });
   }


### PR DESCRIPTION
problems with Stripe because you can only specify allow-promotional-code or discounts. So I made a ternary to check if there is coupon, then only discount param is added, otherwise allow_promotional_code.