### PR TITLE
[MKT-94]: feat/allow-external-providers

### DIFF
--- a/fastify-jwt.d.ts
+++ b/fastify-jwt.d.ts
@@ -4,7 +4,12 @@ declare module '@fastify/jwt' {
   interface FastifyJWT {
     user: {
       payload: {
+        email: string;
         uuid: string;
+        name: string;
+        lastname: string;
+        username: string;
+        sharedWorkspace: boolean,
         networkCredentials: {
           user: string;
           pass: string;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "nodemon src/index.ts",
     "start": "node .",
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "cli": "nodemon src/cli/load-license-codes.ts"
   },
   "devDependencies": {
     "@internxt/eslint-config-internxt": "^1.0.8",
@@ -26,7 +27,8 @@
     "prettier": "^2.6.2",
     "ts-jest": "27",
     "ts-node": "^10.8.0",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.2",
+    "xlsx": "^0.18.5"
   },
   "dependencies": {
     "@fastify/cors": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "axios": "^0.27.2",
     "dotenv": "^16.0.1",
     "fastify": "^3.29.0",
+    "fastify-rate-limit": "^5.9.0",
     "ioredis": "^5.0.6",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^4.6.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,12 +8,14 @@ import { PaymentService } from './services/PaymentService';
 import { StorageService } from './services/StorageService';
 import { UsersService } from './services/UsersService';
 import webhook from './webhooks';
+import { LicenseCodesService } from './services/LicenseCodesService';
 
 export async function buildApp(
   paymentService: PaymentService,
   storageService: StorageService,
   usersService: UsersService,
   cacheService: CacheService,
+  licenseCodesService: LicenseCodesService,
   stripe: Stripe,
   config: AppConfig,
 ): Promise<FastifyInstance> {
@@ -28,7 +30,9 @@ export async function buildApp(
           : false,
     },
   });
-  fastify.register(controller(paymentService, usersService, config, cacheService));
+  fastify.register(
+    controller(paymentService, usersService, config, cacheService, licenseCodesService)
+  );
 
   fastify.register(webhook(stripe, storageService, usersService, paymentService, config, cacheService));
 

--- a/src/cli/load-license-codes.ts
+++ b/src/cli/load-license-codes.ts
@@ -1,0 +1,74 @@
+import { MongoClient } from 'mongodb';
+import XLSX from 'xlsx';
+import Stripe from 'stripe';
+
+import envVariablesConfig from '../config';
+import { LicenseCodesService } from '../services/LicenseCodesService';
+import { PaymentService } from '../services/PaymentService';
+import { UsersService } from '../services/UsersService';
+import { UsersRepository } from '../core/users/UsersRepository';
+import { MongoDBUsersRepository } from '../core/users/MongoDBUsersRepository';
+import { LicenseCodesRepository } from '../core/users/LicenseCodeRepository';
+import { MongoDBLicenseCodesRepository } from '../core/users/MongoDBLicenseCodesRepository';
+import { LicenseCode } from '../core/users/LicenseCode';
+
+const [,,filePath,provider] = process.argv;
+
+if (!filePath || !provider) {
+  throw new Error('Missing "filePath" or "provider" params');
+}
+
+function loadFromExcel(): LicenseCode[] {
+  const licenseCodes: LicenseCode[] = [];
+
+  const workbook = XLSX.readFile(filePath);
+  const sheetName = workbook.SheetNames[0];
+  const worksheet = workbook.Sheets[sheetName];
+  const jsonData = XLSX.utils.sheet_to_json(worksheet);
+
+  jsonData.forEach((_row) => {
+    const row = (_row as Record<Stripe.Price['id'], number>);
+
+    for (const priceId of Object.keys(row)) {
+      licenseCodes.push({
+        code: row[priceId].toString(),
+        priceId,
+        provider: provider,
+        redeemed: false,
+      });
+    }
+  });
+
+  return licenseCodes;
+}
+
+async function main() {
+  const mongoClient = await new MongoClient(envVariablesConfig.MONGO_URI).connect();
+  try {
+    const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2020-08-27' });
+    const usersRepository: UsersRepository = new MongoDBUsersRepository(mongoClient);
+    const licenseCodesRepository: LicenseCodesRepository = new MongoDBLicenseCodesRepository(
+      mongoClient
+    );
+
+    const paymentService = new PaymentService(stripe);
+    const usersService = new UsersService(usersRepository, paymentService);
+    const licenseCodesService = new LicenseCodesService(
+      paymentService,
+      usersService,
+      licenseCodesRepository
+    );
+
+    for (const licenseCode of loadFromExcel()) {
+      await licenseCodesService.insertLicenseCode(licenseCode);
+    } 
+  } finally {
+    await mongoClient.close();
+  }
+}
+
+main().then(() => {
+  console.log('License codes loaded');
+}).catch((err) => {
+  console.error('Error loading license codes', err.message);
+});

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -248,8 +248,6 @@ export default function (
 
     fastify.post<{ 
       Body: {
-        email: string,
-        uuid: string,
         code: string,
         provider: string,
       } 
@@ -259,10 +257,8 @@ export default function (
         schema: {
           body: {
             type: 'object',
-            required: ['email', 'uuid', 'code', 'provider'],
+            required: ['code', 'provider'],
             properties: { 
-              email: { type: 'string' },
-              uuid: { type: 'string' },
               code: { type: 'string' },
               provider: { type: 'string' },
             },
@@ -270,12 +266,12 @@ export default function (
         },
       },
       async (req, rep) => {
-        const { email, uuid, code, provider } = req.body;
+        const { email, uuid, name, lastname } = req.user.payload;
+        const { code, provider } = req.body;
 
         try {
           await licenseCodesService.redeem(
-            email,
-            uuid,
+            { email, uuid, name: `${name} ${lastname}` },
             code,
             provider
           );

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -11,6 +11,8 @@ import {
   LicenseCodeAlreadyAppliedError, 
   LicenseCodesService 
 } from './services/LicenseCodesService';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rateLimit = require('fastify-rate-limit');
 
 export default function (
   paymentService: PaymentService,
@@ -34,6 +36,10 @@ export default function (
 
   return async function (fastify: FastifyInstance) {
     fastify.register(fastifyJwt, { secret: config.JWT_SECRET });
+    fastify.register(rateLimit, {
+      max: 1000,
+      timeWindow: '1 minute'
+    });
     fastify.addHook('onRequest', async (request, reply) => {
       try {
         const config: { url?: string; method?: string } = request.context.config;
@@ -264,6 +270,12 @@ export default function (
             },
           },
         },
+        config: {
+          rateLimit: {
+            max: 5,
+            timeWindow: '1 minute',
+          }
+        }
       },
       async (req, rep) => {
         const { email, uuid, name, lastname } = req.user.payload;

--- a/src/core/users/LicenseCode.ts
+++ b/src/core/users/LicenseCode.ts
@@ -1,0 +1,8 @@
+import Stripe from 'stripe';
+
+export interface LicenseCode {
+  priceId: Stripe.Price['id'];
+  provider: 'OWN' | string;
+  code: string;
+  redeemed: boolean;
+}

--- a/src/core/users/LicenseCodeRepository.ts
+++ b/src/core/users/LicenseCodeRepository.ts
@@ -1,0 +1,7 @@
+import { LicenseCode } from './LicenseCode';
+
+export interface LicenseCodesRepository {
+  findOne(code: LicenseCode['code'], provider: LicenseCode['provider']): Promise<LicenseCode | null>;
+  insert(licenseCode: LicenseCode): Promise<void>;
+  updateByCode(code: LicenseCode['code'], body: Partial<Omit<LicenseCode, 'code'>>): Promise<boolean>;
+}

--- a/src/core/users/MongoDBLicenseCodesRepository.ts
+++ b/src/core/users/MongoDBLicenseCodesRepository.ts
@@ -1,0 +1,50 @@
+import { Collection, MongoClient } from 'mongodb';
+import { LicenseCode } from './LicenseCode';
+
+import { LicenseCodesRepository } from './LicenseCodeRepository';
+
+interface MongoLicenseCode extends Omit<LicenseCode, 'priceId'> {
+  price_id: string;
+}
+
+export class MongoDBLicenseCodesRepository implements LicenseCodesRepository {
+  private readonly collection: Collection<MongoLicenseCode>;
+
+  constructor(mongo: MongoClient) {
+    this.collection = mongo.db('payments').collection<MongoLicenseCode>('license_codes');
+  }
+
+  async findOne(code: LicenseCode['code'], provider: LicenseCode['provider']): Promise<LicenseCode | null> {
+    const licenseCode = await this.collection.findOne({
+      code, 
+      provider
+    });
+
+    if (licenseCode) {
+      return this.toDomain(licenseCode);
+    } else {
+      return null;
+    }
+  }
+
+  async insert(licenseCode: LicenseCode): Promise<void> {
+    await this.collection.insertOne(this.toPersistence(licenseCode));    
+  }
+
+  async updateByCode(code: LicenseCode['code'], body: Partial<Omit<LicenseCode, 'code'>>): Promise<boolean> {
+    const result = await this.collection.updateOne({ code }, { $set: body });
+    return result.matchedCount === 1;
+  }
+
+  private toDomain(licenseCode: MongoLicenseCode): LicenseCode {
+    const { price_id: priceId, code, provider, redeemed } = licenseCode;
+
+    return { priceId, code, provider, redeemed };
+  }
+
+  private toPersistence(licenseCode: LicenseCode): MongoLicenseCode {
+    const { priceId: price_id, code, provider, redeemed } = licenseCode;
+
+    return { price_id, code, provider, redeemed };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,22 +11,34 @@ import { UsersRepository } from './core/users/UsersRepository';
 import { MongoDBUsersRepository } from './core/users/MongoDBUsersRepository';
 import CacheService from './services/CacheService';
 import { buildApp } from './app';
+import { LicenseCodesService } from './services/LicenseCodesService';
+import { LicenseCodesRepository } from './core/users/LicenseCodeRepository';
+import { MongoDBLicenseCodesRepository } from './core/users/MongoDBLicenseCodesRepository';
 
 const start = async (): Promise<FastifyInstance> => {
   const mongoClient = await new MongoClient(envVariablesConfig.MONGO_URI).connect();
   const usersRepository: UsersRepository = new MongoDBUsersRepository(mongoClient);
+  const licenseCodesRepository: LicenseCodesRepository = new MongoDBLicenseCodesRepository(
+    mongoClient
+  );
 
   const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2020-08-27' });
   const paymentService = new PaymentService(stripe);
   const storageService = new StorageService(envVariablesConfig, axios);
   const usersService = new UsersService(usersRepository, paymentService);
   const cacheService = new CacheService(envVariablesConfig);
+  const licenseCodesService = new LicenseCodesService(
+    paymentService,
+    usersService,
+    licenseCodesRepository
+  );
 
   const fastify = await buildApp(
     paymentService,
     storageService,
     usersService,
     cacheService,
+    licenseCodesService,
     stripe,
     envVariablesConfig,
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ const start = async (): Promise<FastifyInstance> => {
   const licenseCodesService = new LicenseCodesService(
     paymentService,
     usersService,
+    storageService,
     licenseCodesRepository
   );
 

--- a/src/services/LicenseCodesService.ts
+++ b/src/services/LicenseCodesService.ts
@@ -1,0 +1,64 @@
+import { LicenseCode } from '../core/users/LicenseCode';
+import { LicenseCodesRepository } from '../core/users/LicenseCodeRepository';
+import { User } from '../core/users/User';
+import { PaymentService } from './PaymentService';
+import { UsersService } from './UsersService';
+
+export class InvalidLicenseCodeError extends Error {
+  constructor() {
+    super('Invalid code provided');
+
+    Object.setPrototypeOf(this, InvalidLicenseCodeError.prototype);
+  }
+}
+
+export class LicenseCodeAlreadyAppliedError extends Error {
+  constructor() {
+    super('Code already applied');
+
+    Object.setPrototypeOf(this, LicenseCodeAlreadyAppliedError.prototype);
+  }
+}
+
+export class LicenseCodesService {
+  constructor(
+    private readonly paymentService: PaymentService,
+    private readonly usersService: UsersService,
+    private readonly licenseCodesRepository: LicenseCodesRepository
+  ) {}
+
+  async redeem(
+    email: string,
+    uuid: User['uuid'],
+    code: LicenseCode['code'],
+    provider: LicenseCode['provider'],
+  ): Promise<void> {
+    const licenseCode = await this.licenseCodesRepository.findOne(
+      code, 
+      provider
+    );
+
+    if (licenseCode === null) {
+      throw new InvalidLicenseCodeError();
+    }
+
+    if (licenseCode.redeemed) {
+      throw new LicenseCodeAlreadyAppliedError();
+    }
+
+    const customer = await this.paymentService.createCustomer({ email });
+    await this.paymentService.subscribe(
+      customer.id,
+      licenseCode.priceId,
+    );
+    await this.usersService.insertUser({
+      customerId: customer.id,
+      uuid,
+      lifetime: false,
+    });
+  }
+
+  async insertLicenseCode(licenseCode: LicenseCode): Promise<void> {
+    await this.licenseCodesRepository.insert(licenseCode);
+  }
+}

--- a/src/services/LicenseCodesService.ts
+++ b/src/services/LicenseCodesService.ts
@@ -2,6 +2,7 @@ import { LicenseCode } from '../core/users/LicenseCode';
 import { LicenseCodesRepository } from '../core/users/LicenseCodeRepository';
 import { User } from '../core/users/User';
 import { PaymentService } from './PaymentService';
+import { StorageService } from './StorageService';
 import { UsersService } from './UsersService';
 
 export class InvalidLicenseCodeError extends Error {
@@ -24,12 +25,16 @@ export class LicenseCodesService {
   constructor(
     private readonly paymentService: PaymentService,
     private readonly usersService: UsersService,
+    private readonly storageService: StorageService,
     private readonly licenseCodesRepository: LicenseCodesRepository
   ) {}
 
   async redeem(
-    email: string,
-    uuid: User['uuid'],
+    user: {
+      email: string, 
+      uuid: User['uuid'],
+      name?: string,
+    },
     code: LicenseCode['code'],
     provider: LicenseCode['provider'],
   ): Promise<void> {
@@ -46,16 +51,41 @@ export class LicenseCodesService {
       throw new LicenseCodeAlreadyAppliedError();
     }
 
-    const customer = await this.paymentService.createCustomer({ email });
-    await this.paymentService.subscribe(
-      customer.id,
+    const maybeExistingUser = await this.usersService.findUserByUuid(user.uuid).catch(() => null);
+    let customerId: string;
+
+    // 1. Create or get customer from Stripe
+    if (!maybeExistingUser) {
+      customerId = (await this.paymentService.createCustomer({ 
+        name: user.name || 'Internxt User',
+        email: user.email,
+      })).id;
+    } else {
+      customerId = (await this.paymentService.getCustomer(maybeExistingUser.customerId)).id;
+    }
+    
+    // 2. Subscribe to the price referenced by the code
+    const productMetadata = await this.paymentService.subscribe(
+      customerId,
       licenseCode.priceId,
-    );
-    await this.usersService.insertUser({
-      customerId: customer.id,
-      uuid,
-      lifetime: false,
-    });
+    ); 
+
+    // 3. Set the storage referenced by the code
+    await this.storageService.changeStorage(user.uuid, productMetadata.maxSpaceBytes);  
+ 
+    // 4. Update user accordingly
+    if (!maybeExistingUser) {
+      await this.usersService.insertUser({
+        customerId,
+        uuid: user.uuid,
+        lifetime: !productMetadata.recurring,
+      });
+    } else {
+      await this.usersService.updateUser(maybeExistingUser.customerId, { lifetime: !productMetadata.recurring });
+    }
+
+    // 5. Mark code as redeemed
+    await this.licenseCodesRepository.updateByCode(licenseCode.code, { redeemed: true });
   }
 
   async insertLicenseCode(licenseCode: LicenseCode): Promise<void> {

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -45,6 +45,28 @@ export class PaymentService {
     this.provider = provider;
   }
 
+  async createCustomer(payload: Stripe.CustomerCreateParams): Promise<Stripe.Customer> {
+    const customer = await this.provider.customers.create(payload);
+    
+    return customer;
+  }
+
+  async subscribe(
+    customerId: CustomerId,
+    priceId: PriceId
+  ): Promise<Stripe.Subscription> {
+    const subscription = await this.provider.subscriptions.create({
+      customer: customerId,
+      items: [
+        {
+          price: priceId,
+        }
+      ]
+    });
+
+    return subscription;
+  }
+
   async cancelSubscription(subscriptionId: SubscriptionId): Promise<void> {
     await this.provider.subscriptions.del(subscriptionId, {});
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,6 +1938,23 @@ fastify-plugin@^3.0.0, fastify-plugin@^3.0.1:
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-3.0.1.tgz#79e84c29f401020f38b524f59f2402103fd21ed2"
   integrity sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA==
 
+"fastify-rate-limit-deprecated@npm:fastify-rate-limit@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/fastify-rate-limit/-/fastify-rate-limit-5.8.0.tgz#5f87c51a90232c15eadb23bbb4d2d2b30adf821f"
+  integrity sha512-sln2ZbEG1cb0Ok4pn+tXrZIU0zJUWEimANWB/Bq+z/Ad5fBys9YsmCySrPqhUdBcZHwk9ymX22wbgZvvNLokyQ==
+  dependencies:
+    fastify-plugin "^3.0.1"
+    ms "^2.1.3"
+    tiny-lru "^8.0.1"
+
+fastify-rate-limit@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/fastify-rate-limit/-/fastify-rate-limit-5.9.0.tgz#36ec2c5806ceebdb84a1a8f8b6fc2652c3e9ea56"
+  integrity sha512-v+w/Q7wUWEdefvhUtqEhUyjg4DThjGQTlfYDOR0tgave6MbsBnCwZhRoEF1mVVa3mLb4eHXY9WH8TaRDvZt8Lg==
+  dependencies:
+    fastify-rate-limit-deprecated "npm:fastify-rate-limit@5.8.0"
+    process-warning "^1.0.0"
+
 fastify@^3.29.0:
   version "3.29.0"
   resolved "https://registry.yarnpkg.com/fastify/-/fastify-3.29.0.tgz#b840107f4fd40cc999b886548bfcda8062e38168"
@@ -3323,7 +3340,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,11 @@ acorn@^8.2.4, acorn@^8.4.1, acorn@^8.7.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
+adler-32@~1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.3.1.tgz#1dbf0b36dda0012189a32b3679061932df1821e2"
+  integrity sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -1286,6 +1291,14 @@ caniuse-lite@^1.0.30001332:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz#8a1e7fdc4db9c2ec79a05e9fd68eb93a761888bb"
   integrity sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==
 
+cfb@~1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.2.2.tgz#94e687628c700e5155436dac05f74e08df23bc44"
+  integrity sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==
+  dependencies:
+    adler-32 "~1.3.0"
+    crc-32 "~1.2.0"
+
 chalk@2.4.2, chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1369,6 +1382,11 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
+codepage@~1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.15.0.tgz#2e00519024b39424ec66eeb3ec07227e692618ab"
+  integrity sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
@@ -1438,6 +1456,11 @@ cookie@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+crc-32@~1.2.0, crc-32@~1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -2043,6 +2066,11 @@ forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+frac@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
+  integrity sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3976,6 +4004,13 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+ssf@~0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.11.2.tgz#0b99698b237548d088fc43cdf2b70c1a7512c06c"
+  integrity sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==
+  dependencies:
+    frac "~1.1.2"
+
 stack-utils@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
@@ -4446,10 +4481,20 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
+wmf@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wmf/-/wmf-1.0.2.tgz#7d19d621071a08c2bdc6b7e688a9c435298cc2da"
+  integrity sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==
+
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+word@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
+  integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -4484,6 +4529,19 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xlsx@^0.18.5:
+  version "0.18.5"
+  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.18.5.tgz#16711b9113c848076b8a177022799ad356eba7d0"
+  integrity sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==
+  dependencies:
+    adler-32 "~1.3.0"
+    cfb "~1.2.1"
+    codepage "~1.15.0"
+    crc-32 "~1.2.1"
+    ssf "~0.11.2"
+    wmf "~1.0.1"
+    word "~0.3.0"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Allows the service to accept external providers who share with us the codes of the purchases made by their customers:
- They provide an Excel of codes with the related plans. We use the Stripe Price IDs to relate it to our payments processor which is Stripe
- Then, we just adjust the data to match the same data that will be existing on any purchase made via Stripe, except the payment method.