### PR TITLE
[_]: Fix/redeem codes to external codes

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -73,7 +73,7 @@ export class PaymentService {
       const invoice = await this.provider.invoices.create({
         customer: customerId,
         auto_advance: false,
-        pending_invoice_items_behavior: 'include_and_require',
+        pending_invoice_items_behavior: 'include',
       });
 
       await this.provider.invoices.pay(invoice.id, {


### PR DESCRIPTION
The problem was that pending_invoice_items_behavior had the value 'include_and_require' which is not allowed by this parameter and gave an error when the user tried to redeem a code from an external provider. So, the value has been changed to 'include' which will include any pending invoice items and will create an empty draft invoice if no pending invoice items exist.