### PR TITLE
[PB-706/PB-692]: fix/trial when cancelling plan

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -124,7 +124,11 @@ export default function (
         const { price_id: priceId, couponCode } = req.body;
 
         const user = await assertUser(req, rep);
-        await paymentService.updateSubscriptionPrice(user.customerId, priceId, couponCode);
+        await paymentService.updateSubscriptionPrice({
+          customerId: user.customerId,
+          priceId: priceId,
+          couponCode: couponCode,
+        });
 
         const updatedSubscription = await paymentService.getUserSubscription(user.customerId);
         return rep.send(updatedSubscription);

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -149,6 +149,7 @@ export class PaymentService {
         },
       ],
       billing_cycle_anchor: billingCycleAnchor,
+      trial_end: 'now',
       ...additionalOptions,
     });
 

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -127,13 +127,11 @@ export class PaymentService {
     priceId,
     couponCode,
     additionalOptions,
-    isFreeTrial,
   }: {
     customerId: CustomerId;
     priceId: PriceId;
     couponCode?: string;
     additionalOptions?: Partial<Stripe.SubscriptionUpdateParams>;
-    isFreeTrial?: boolean;
   }): Promise<Subscription> {
     // If the user uses the free trial, then create_prorations must be none and billingCycleAnchor must be undefined to avoid
     // overcharging the user


### PR DESCRIPTION
**PROBLEMS:**
The user is not charged the price he should be when using the free trial. We should add 3 months free and, once finished, charge the user for the plan without the 3-month discount.

If the user wants to upgrade his plan with the free trial, he will not be able to upgrade (either to a coupon code plan or to a normal plan).

**HOW TO SOLVE IT:**
If the user uses the free trial offer, we must set prorations_behavior to 'none'. If we want to upgrade a plan, we must add proration_behavior to 'create_proprations' and billing_cycle_behavior to 'now'. 

We have added trial_end: 'now' so that if the user upgrades his plan to have a free trial, he can do it without any problem.

**INFO:**
https://stripe.com/docs/billing/subscriptions/billing-cycle#prorating-changes-through-the-api