### PR TITLE
[_]: fix/remove billing cycle param

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -124,14 +124,18 @@ export default function (
         const { price_id: priceId, couponCode } = req.body;
 
         const user = await assertUser(req, rep);
-        await paymentService.updateSubscriptionPrice({
+        const updateSub = await paymentService.updateSubscriptionPrice({
           customerId: user.customerId,
           priceId: priceId,
           couponCode: couponCode,
         });
 
         const updatedSubscription = await paymentService.getUserSubscription(user.customerId);
-        return rep.send(updatedSubscription);
+        return rep.send({
+          updatedSubscription,
+          request3DSecure: updateSub.request3DSecure,
+          clientSecret: updateSub.clientSecret,
+        });
       },
     );
 

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -135,7 +135,6 @@ export class PaymentService {
     additionalOptions?: Partial<Stripe.SubscriptionUpdateParams>;
     isFreeTrial?: boolean;
   }): Promise<Subscription> {
-    const billingCycleAnchor: Stripe.SubscriptionUpdateParams = !isFreeTrial ? { billing_cycle_anchor: 'now' } : {};
     const individualActiveSubscription = await this.findIndividualActiveSubscription(customerId);
     const updatedSubscription = await this.provider.subscriptions.update(individualActiveSubscription.id, {
       cancel_at_period_end: false,
@@ -148,10 +147,8 @@ export class PaymentService {
         },
       ],
       trial_end: 'now',
-      ...billingCycleAnchor,
       ...additionalOptions,
     });
-
     return updatedSubscription;
   }
 

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -66,7 +66,6 @@ export default function (
             (event.data.object as Stripe.PaymentMethod).id,
           );
           break;
-
         case 'checkout.session.completed':
           await handleCheckoutSessionCompleted(
             event.data.object as Stripe.Checkout.Session,


### PR DESCRIPTION
**PROBLEM:**
When the user update the subscription, Stripe request for the 3D Secure again.

**FIX:**
I think the problem is `billing_cycle_anchor` because the user has to pay again, so let's remove that until Stripe give us a solution.

If the problem persists, I will look for another solution.