### PR TITLE
[PB-706/PB-692]: fix/payment issues

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -194,7 +194,7 @@ export default function (
       } catch (err) {
         const error = err as Error;
         req.log.error(
-          `[REQUEST-PREVENT-CANCELLATION] ERROR for user ${uuid} ${error.message}. ${error.stack || 'NO STACK'}`,
+          `[REQUEST-PREVENT-CANCELLATION/ERROR]: Error for user ${uuid} ${error.message}. ${error.stack || 'NO STACK'}`,
         );
         throw err;
       }


### PR DESCRIPTION
**PROBLEMS:**
* Cancellation flow (add 3 free months for the active subscription).
* Update/downgrade subscription does not work properly.

**FIX:**
* For the cancellation flow, the user will pay the total amount when the trial + subscription ends.
* To update/downgrade a subscription, the user will pay the total amount every time he changes the sub.
