### PR TITLE
[_]: fix/charge the total price when updating sub

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -129,6 +129,7 @@ export class PaymentService {
     const updatedSubscription = await this.provider.subscriptions.update(individualActiveSubscription.id, {
       cancel_at_period_end: false,
       proration_behavior: 'none',
+      billing_cycle_anchor: 'now',
       items: [
         {
           id: individualActiveSubscription.items.data[0].id,


### PR DESCRIPTION
**EXPECTED BEHAVIOR:**
We should always charge the user when he upgrades to another subscription, regardless of the plan.

**PROBLEM:**
When the user upgrades the subscription to another price of the same billing frequency (sub monthly -> sub monthly), then he pays nothing until the next billing. Eg.:
The user purchases an annual subscription on August 10 and upgrades it on September 15, he will pay nothing until August 10 of the following year.

[Example](https://dashboard.stripe.com/customers/cus_PHZXnZmj2eKqia).

**FIX:** 
Now, we set the billing cycle anchor to now to charge the price at the time regardless of which subscription the user wants to upgrade to.

[Stripe docs](https://stripe.com/docs/billing/subscriptions/billing-cycle#changing).