### PR TITLE
[_]: fix/prevent cancellation flow

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -108,7 +108,7 @@ export class PaymentService {
   }
 
   /**
-   * Function to update a normal subscription
+   * Function to update the subscription that contains the basic params
    *
    * @param customerId - The customer id
    * @param priceId - The price id

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -108,7 +108,7 @@ export class PaymentService {
   }
 
   /**
-   * Function to update the subscription that contains the basic params
+   * Function to update a normal subscription
    *
    * @param customerId - The customer id
    * @param priceId - The price id
@@ -129,7 +129,6 @@ export class PaymentService {
     const updatedSubscription = await this.provider.subscriptions.update(individualActiveSubscription.id, {
       cancel_at_period_end: false,
       proration_behavior: 'none',
-      billing_cycle_anchor: 'now',
       items: [
         {
           id: individualActiveSubscription.items.data[0].id,
@@ -196,6 +195,7 @@ export class PaymentService {
       priceId: priceId,
       additionalOptions: {
         coupon: couponCode,
+        billing_cycle_anchor: 'now',
       },
     });
 


### PR DESCRIPTION
**EXPECTED BEHAVIOR:**
When the user has a subscription and wants to cancel it, we offer 3 months free. If the user selects the offer, then we apply a 3 month free trial to that same sub they already have.

**PROBLEM:**
Using billing_anchor_tag="now" is not possible while trying to add a free trial.

**FIX:**
We add the billing_anchor_tag parameter only when the user tries to update a normal subscription through additionalParams. Thus, the updateSub function has only the basic parameters to work in all cases.