### PR TITLE
feat: get plan name with user subscription

### DIFF
--- a/src/core/users/User.ts
+++ b/src/core/users/User.ts
@@ -14,4 +14,5 @@ export type UserSubscription =
       interval: 'year' | 'month';
       nextPayment: number;
       priceId: string;
+      planName?: string;
     };

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -343,6 +343,7 @@ export class PaymentService {
       nextPayment: subscription.current_period_end,
       amountAfterCoupon: upcomingInvoice.total,
       priceId: price.id,
+      planName: (subscription as any)?.plan?.metadata?.name ?? undefined
     };
   }
 


### PR DESCRIPTION
We need to get the planName from the subscription object to be able to match them with feature limits per plan.

Note: Stripe subscription type seems to be old in this project, so the type Stripe.Subscription complains when you try to get "plans" from the subscription object. However, it is retrieved successfully in the subscription object, therefore, I added a cast to any. (check https://docs.stripe.com/api/subscriptions)

Object we could get now when asking for user subscription:

```
{
    "type": "subscription",
    "amount": 4188,
    "currency": "eur",
    "interval": "year",
    "nextPayment": 1739451211,
    "amountAfterCoupon": 4188,
    "priceId": "price_1OU40vFAOdcgaBMQ4KQyNqV2",
    "planName": "drive_200gb_subscription_individual"
}
```

If planName does not exist, we just omit planName

```
{
    "type": "subscription",
    "amount": 4188,
    "currency": "eur",
    "interval": "year",
    "nextPayment": 1739451211,
    "amountAfterCoupon": 4188,
    "priceId": "price_1OU40vFAOdcgaBMQ4KQyNqV2"
  }
```