### PR TITLE
chore: added temporal endpoint for plans migration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import Stripe from 'stripe';
 import { type AppConfig } from './config';
 import controller from './controller';
+import controllerMigration from './controller-migration';
 import CacheService from './services/CacheService';
 import { PaymentService } from './services/PaymentService';
 import { StorageService } from './services/StorageService';
@@ -32,6 +33,10 @@ export async function buildApp(
   });
   fastify.register(
     controller(paymentService, usersService, config, cacheService, licenseCodesService)
+  );
+
+  fastify.register(
+    controllerMigration(paymentService, usersService, config)
   );
 
   fastify.register(webhook(stripe, storageService, usersService, paymentService, config, cacheService));

--- a/src/controller-migration.ts
+++ b/src/controller-migration.ts
@@ -28,7 +28,7 @@ export default function (
   return async function (fastify: FastifyInstance) {
     fastify.register(fastifyJwt, { secret: config.JWT_SECRET });
     fastify.register(rateLimit, {
-      max: 30, // Modify this according to Stripe rate limit. Max 100 requests per second 
+      max: 30, // Set according to stripe limits.
       timeWindow: '1 second',
     });
     fastify.addHook('onRequest', async (request, reply) => {

--- a/src/controller-migration.ts
+++ b/src/controller-migration.ts
@@ -1,0 +1,54 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { type AppConfig } from './config';
+import { UserNotFoundError, UsersService } from './services/UsersService';
+import { PaymentService } from './services/PaymentService';
+import fastifyJwt from '@fastify/jwt';
+import { User, UserSubscription } from './core/users/User';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rateLimit = require('fastify-rate-limit');
+
+export default function (
+  paymentService: PaymentService,
+  usersService: UsersService,
+  config: AppConfig,
+) {
+  async function assertUser(req: FastifyRequest, rep: FastifyReply): Promise<User> {
+    const { uuid } = req.user.payload;
+    try {
+      return await usersService.findUserByUuid(uuid);
+    } catch (err) {
+      if (err instanceof UserNotFoundError) {
+        req.log.info(`User with uuid ${uuid} was not found`);
+        return rep.status(404).send({ message: 'User not found' });
+      }
+      throw err;
+    }
+  }
+
+  return async function (fastify: FastifyInstance) {
+    fastify.register(fastifyJwt, { secret: config.JWT_SECRET });
+    fastify.register(rateLimit, {
+      max: 30, // Modify this according to Stripe rate limit, do we want to only get 30 of the  100 concurrent requests per second that stripe allows? This handles that  
+      timeWindow: '1 second',
+    });
+    fastify.addHook('onRequest', async (request, reply) => {
+      try {        
+        await request.jwtVerify();
+      } catch (err) {
+        request.log.warn(`JWT verification failed with error: ${(err as Error).message}`);
+        reply.status(401).send();
+      }
+    });
+
+    fastify.get('/get-user-subscription', async (req, rep) => {
+        let response: UserSubscription;
+  
+        const user: User = await assertUser(req, rep);
+  
+        response = await paymentService.getUserSubscription(user.customerId);
+  
+        return response;
+      });
+
+  };
+}

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -185,6 +185,17 @@ export default function (
       return response;
     });
 
+
+    fastify.get('/get-user-subscription', async (req, rep) => {
+      let response: UserSubscription;
+
+      const user: User = await assertUser(req, rep);
+
+      response = await paymentService.getUserSubscription(user.customerId);
+
+      return response;
+    });
+
     function checkCurrency(currency?: string): { currencyValue: string; isError: boolean; errorMessage?: string } {
       let currencyValue: string;
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -185,17 +185,6 @@ export default function (
       return response;
     });
 
-
-    fastify.get('/get-user-subscription', async (req, rep) => {
-      let response: UserSubscription;
-
-      const user: User = await assertUser(req, rep);
-
-      response = await paymentService.getUserSubscription(user.customerId);
-
-      return response;
-    });
-
     function checkCurrency(currency?: string): { currencyValue: string; isError: boolean; errorMessage?: string } {
       let currencyValue: string;
 

--- a/src/core/users/User.ts
+++ b/src/core/users/User.ts
@@ -14,4 +14,5 @@ export type UserSubscription =
       interval: 'year' | 'month';
       nextPayment: number;
       priceId: string;
+      planId?: string;
     };

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -343,6 +343,7 @@ export class PaymentService {
       nextPayment: subscription.current_period_end,
       amountAfterCoupon: upcomingInvoice.total,
       priceId: price.id,
+      planId: price?.product as string
     };
   }
 


### PR DESCRIPTION
Currently, the `/subscriptions` endpoint does not make a request to  Stripe if the user has a lifetime subscription, it is not required for its use case so it makes sense.

Therefore, we need a similar temporal endpoint that brings the productId (if the user has 200gb, 1tb plans, etc) from stripe, even if the user has lifetime. 

This will also start sending the productId to /subscriptions, however, it is harmless. @masterprog-cmd  feel free to confirm if it affects something.

Example of returned data
```json
{
    "planId": "prod_NXNb9cOS28ubg5",
    "type": "lifetime",
    "uuid": "7bd7ee09-c704-452b-bb0d-51302e9884b5"
}
```

### How do we get productId of lifetime subscriptions?
When you adquire a lifetime plan, a subscription is not created, Stripe does not create subscriptions for prices of 'one_time' type. The only way is to get them through invoices. If use is stored in our database with lifetime: true, then we can get the most recent payment that has all the flags we are looking for.

### **Why is declared in a new controller?**  
I thought it would be good if we can set a special rate limit for this endpoint to protect Stripe's rate limit [check it here](https://docs.stripe.com/rate-limits#:~:text=For%20most%20APIs%2C%20Stripe%20allows,live%20mode%20and%20test%20mode.)