### PR TITLE
[PB-2117]: feat/get active b2b subscriptions

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -155,14 +155,14 @@ export default function (
     });
 
     fastify.get<{
-      Querystring: { subscription_type?: 'B2B' };
+      Querystring: { subscriptionType?: 'B2B' };
     }>(
       '/subscriptions',
       {
         schema: {
           querystring: {
             type: 'object',
-            properties: { subscription_type: { type: 'string', enum: ['B2B'] } },
+            properties: { subscriptionType: { type: 'string', enum: ['B2B'] } },
           },
         },
       },
@@ -170,7 +170,7 @@ export default function (
         let response: UserSubscription;
 
         const user: User = await assertUser(req, rep);
-        const subscriptionType = req.query.subscription_type ?? 'individual';
+        const subscriptionType = req.query.subscriptionType ?? 'individual';
 
         let subscriptionInCache: UserSubscription | null | undefined;
         try {

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -479,9 +479,8 @@ export class PaymentService {
     const activeSubscriptions = await this.getActiveSubscriptions(customerId);
 
     const individualActiveSubscription = activeSubscriptions.find((subscription) => {
-      const isNotTeams = subscription.items.data[0].price.metadata.is_teams !== '1';
       const isNotBusiness = subscription.product?.metadata?.type !== 'business';
-      return isNotTeams && isNotBusiness;
+      return isNotBusiness;
     });
     if (!individualActiveSubscription) {
       throw new NotFoundSubscriptionError('There is no individual subscription to update');


### PR DESCRIPTION
Modify subscriptions endpoint to allow the retrieval of B2B subscriptions based on the metadata field on product `type="business"`. All products missing this metadata field are treated as if they where `"individual"` plans.