### PR TITLE
[PB-2194]: feat/seat count handling on b2b subscriptions

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -285,6 +285,7 @@ export default function (
         trial_days?: number;
         mode?: string;
         currency?: string;
+        seats?: number;
       };
     }>(
       '/checkout-session',
@@ -296,6 +297,7 @@ export default function (
             properties: {
               mode: { type: 'string' },
               price_id: { type: 'string' },
+              seats: { type: 'number' },
               trial_days: { type: 'number' },
               coupon_code: { type: 'string' },
               success_url: { type: 'string' },
@@ -308,7 +310,8 @@ export default function (
       },
       async (req, rep) => {
         const { uuid } = req.user.payload;
-        const { price_id, success_url, cancel_url, customer_email, trial_days, mode, coupon_code, currency } = req.body;
+        const { price_id, success_url, cancel_url, customer_email, trial_days, mode, coupon_code, currency, seats } =
+          req.body;
 
         const { currencyValue, isError, errorMessage } = checkCurrency(currency);
 
@@ -333,6 +336,7 @@ export default function (
           trialDays: trial_days,
           couponCode: coupon_code,
           currency: currencyValue,
+          seats,
         });
 
         return { sessionId: id };

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -145,7 +145,7 @@ export class UsersService {
     return !!userCouponEntry;
   }
 
-  async initializeWorkspace(ownerId: string, newStorageBytes: number, address?: string): Promise<void> {
+  async initializeWorkspace(ownerId: string, newStorageBytes: number, seats: number, address?: string): Promise<void> {
     const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
     const params: AxiosRequestConfig = {
       headers: {
@@ -158,7 +158,7 @@ export class UsersService {
       `${this.config.DRIVE_NEW_GATEWAY_URL}/gateway/workspaces`,
       {
         ownerId,
-        maxSpaceBytes: newStorageBytes,
+        maxSpaceBytes: newStorageBytes * seats,
         address: address,
       },
       params,

--- a/src/webhooks/handleCheckoutSessionCompleted.ts
+++ b/src/webhooks/handleCheckoutSessionCompleted.ts
@@ -111,7 +111,8 @@ export default async function handleCheckoutSessionCompleted(
   }
 
   if (product.metadata?.type === 'business') {
-    const address = customer.address?.line1 || undefined;
-    await usersService.initializeWorkspace(user.uuid, Number(maxSpaceBytes), address);
+    const amountOfSeats = lineItems.data[0]!.quantity ?? parseInt(price.metadata.minimumSeats);
+    const address = customer.address?.line1 ?? undefined;
+    await usersService.initializeWorkspace(user.uuid, Number(maxSpaceBytes), amountOfSeats, address);
   }
 }

--- a/src/webhooks/handleCheckoutSessionCompleted.ts
+++ b/src/webhooks/handleCheckoutSessionCompleted.ts
@@ -111,7 +111,7 @@ export default async function handleCheckoutSessionCompleted(
   }
 
   if (product.metadata?.type === 'business') {
-    const amountOfSeats = lineItems.data[0]!.quantity ?? parseInt(price.metadata.minimumSeats);
+    const amountOfSeats = lineItems.data[0]!.quantity!;
     const address = customer.address?.line1 ?? undefined;
     await usersService.initializeWorkspace(user.uuid, Number(maxSpaceBytes), amountOfSeats, address);
   }


### PR DESCRIPTION
When creating a checkout session if the product is B2B based on the metadata `type === 'business'` quantity becomes modifiable using Stripe's `adjustable_quantity` property, where `minimum` and `maximum` are set based on price metadata properties `minimumSeats` and `maximumSeats` respectively.

When handleCheckoutSessionHook is triggered quantity is taken from lineItems in order to call initializeWorkspace with `maxSpaceBytes: newStorageBytes * seats`.