### PR TITLE
[PB-2115] feat: b2b update subscription payment method

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -172,12 +172,19 @@ export default function (
       },
     );
 
-    fastify.get('/setup-intent', async (req, rep) => {
-      const user = await assertUser(req, rep);
-      const { client_secret: clientSecret } = await paymentService.getSetupIntent(user.customerId);
+    fastify.get<{
+      Querystring: { subscriptionType?: 'individual' | 'business'; };
+    }>(
+      '/setup-intent',
+      async (req, rep) => {
+        const user = await assertUser(req, rep);
+        const { subscriptionType } = req.query;
+        const metadata: Stripe.MetadataParam = subscriptionType ? { subscriptionType } : {};
+        const { client_secret: clientSecret } = await paymentService.getSetupIntent(user.customerId, metadata);
 
-      return { clientSecret };
-    });
+        return { clientSecret };
+      },
+    );
 
     fastify.get<{
       Querystring: { subscriptionType?: 'individual' | 'business'; };

--- a/src/core/users/User.ts
+++ b/src/core/users/User.ts
@@ -16,6 +16,7 @@ export type UserSubscription =
   | { type: 'free' | 'lifetime' }
   | {
       type: 'subscription';
+      subscriptionId: string;
       amount: number;
       currency: string;
       amountAfterCoupon?: number;

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -269,7 +269,7 @@ export class PaymentService {
     paymentMethodId: PaymentMethod['id'],
     userType: UserType = UserType.Individual,
   ): Promise<Subscription> {
-    const { id: subscriptionId } = userType == UserType.Business
+    const { id: subscriptionId } = userType === UserType.Business
       ? await this.findBusinessActiveSubscription(customerId)
       : await this.findIndividualActiveSubscription(customerId);
 
@@ -393,9 +393,9 @@ export class PaymentService {
     if (subscriptions.length === 0)
       return null;
 
-    subscriptions = userType == UserType.Business
-      ? subscriptions.filter(subs => subs.product?.metadata?.type == UserType.Business)
-      : subscriptions.filter(subs => subs.product?.metadata?.type != UserType.Business);
+    subscriptions = userType === UserType.Business
+      ? subscriptions.filter(subs => subs.product?.metadata?.type === UserType.Business)
+      : subscriptions.filter(subs => subs.product?.metadata?.type !== UserType.Business);
 
     const subscriptionWithDefaultPaymentMethod = subscriptions.find(
       (subscription) => subscription.default_payment_method,
@@ -417,7 +417,7 @@ export class PaymentService {
   }
 
   getPaymentMethod(paymentMethod: string | Stripe.PaymentMethod): Promise<PaymentMethod> {
-    return typeof paymentMethod == 'string'
+    return typeof paymentMethod === 'string'
       ? this.provider.paymentMethods.retrieve(paymentMethod)
       : this.provider.paymentMethods.retrieve(paymentMethod.id);
   }

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -267,10 +267,10 @@ export class PaymentService {
   async updateSubscriptionPaymentMethod(
     customerId: CustomerId,
     paymentMethodId: PaymentMethod['id'],
-    subscriptionType: 'individual' | 'business' = 'individual',
+    userType: UserType = UserType.Individual,
   ): Promise<Subscription> {
-    const { id: subscriptionId } = subscriptionType == 'business'
-      ? await this.findB2BActiveSubscription(customerId)
+    const { id: subscriptionId } = userType == UserType.Business
+      ? await this.findBusinessActiveSubscription(customerId)
       : await this.findIndividualActiveSubscription(customerId);
 
     if (!subscriptionId)
@@ -469,6 +469,7 @@ export class PaymentService {
 
     return {
       type: 'subscription',
+      subscriptionId: subscription.id,
       amount: price.unit_amount!,
       currency: price.currency,
       interval: price.recurring!.interval as 'year' | 'month',

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -181,6 +181,25 @@ export class UsersService {
     );
   }
 
+  async updateWorkspaceStorage(ownerId: string, maxSpaceBytes: number): Promise<void> {
+    const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
+    const requestConfig: AxiosRequestConfig = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${jwt}`,
+      },
+      data: {
+        ownerId,
+        maxSpaceBytes,
+      },
+    };
+
+    await this.axios.put(
+      `${this.config.DRIVE_NEW_GATEWAY_URL}/gateway/workspaces/storage`,
+      requestConfig,
+    );
+  }
+
   async destroyWorkspace(ownerId: string): Promise<void> {
     const jwt = signToken('5m', this.config.DRIVE_NEW_GATEWAY_SECRET);
     const requestConfig: AxiosRequestConfig = {

--- a/src/webhooks/handleSetupIntentSucceded.ts
+++ b/src/webhooks/handleSetupIntentSucceded.ts
@@ -1,0 +1,20 @@
+import Stripe from 'stripe';
+import { PaymentService } from '../services/PaymentService';
+
+type SubscriptionType = 'individual' | 'business';
+
+export default async function handleSetupIntentSucceded(
+  setupIntent: Stripe.SetupIntent,
+  paymentService: PaymentService,
+): Promise<void> {
+  const customerId = setupIntent.customer as string;
+  const paymentMethodId = setupIntent.payment_method as string;
+  const setupIntentMetdata = setupIntent.metadata as Stripe.Metadata;
+  
+  const subscriptionType: SubscriptionType = setupIntentMetdata?.subscriptionType as SubscriptionType;
+  const setupSubscriptionPayment = subscriptionType === 'business' || subscriptionType === 'individual';
+
+  if (setupSubscriptionPayment) {
+    await paymentService.updateSubscriptionPaymentMethod(customerId, paymentMethodId, subscriptionType);
+  }
+}

--- a/src/webhooks/handleSetupIntentSucceded.ts
+++ b/src/webhooks/handleSetupIntentSucceded.ts
@@ -1,7 +1,6 @@
 import Stripe from 'stripe';
 import { PaymentService } from '../services/PaymentService';
-
-type SubscriptionType = 'individual' | 'business';
+import { UserType } from '../core/users/User';
 
 export default async function handleSetupIntentSucceded(
   setupIntent: Stripe.SetupIntent,
@@ -9,12 +8,11 @@ export default async function handleSetupIntentSucceded(
 ): Promise<void> {
   const customerId = setupIntent.customer as string;
   const paymentMethodId = setupIntent.payment_method as string;
-  const setupIntentMetdata = setupIntent.metadata as Stripe.Metadata;
+  const setupIntentMetadata = setupIntent.metadata as Stripe.Metadata;
   
-  const subscriptionType: SubscriptionType = setupIntentMetdata?.subscriptionType as SubscriptionType;
-  const setupSubscriptionPayment = subscriptionType === 'business' || subscriptionType === 'individual';
+  const userType = setupIntentMetadata?.userType as UserType;
 
-  if (setupSubscriptionPayment) {
-    await paymentService.updateSubscriptionPaymentMethod(customerId, paymentMethodId, subscriptionType);
+  if ([UserType.Individual, UserType.Business].includes(userType)) {
+    await paymentService.updateSubscriptionPaymentMethod(customerId, paymentMethodId, userType);
   }
 }

--- a/src/webhooks/handleSubscriptionUpdated.ts
+++ b/src/webhooks/handleSubscriptionUpdated.ts
@@ -6,6 +6,7 @@ import { PaymentService, PriceMetadata } from '../services/PaymentService';
 import { StorageService, updateUserTier } from '../services/StorageService';
 import { UsersService } from '../services/UsersService';
 import { AppConfig } from '../config';
+import { UserType } from '../core/users/User';
 
 export default async function handleSubscriptionUpdated(
   storageService: StorageService,
@@ -24,7 +25,7 @@ export default async function handleSubscriptionUpdated(
 
   const productId = subscription.items.data[0].price.product as string;
   const { metadata : productMetadata } = await paymentService.getProduct(productId);
-  const productType = productMetadata?.type === 'business' ? 'business' : 'individual';
+  const productType = productMetadata?.type === UserType.Business ? UserType.Business : UserType.Individual;
 
   try {
     await cacheService.clearSubscription(customerId, productType);
@@ -32,7 +33,7 @@ export default async function handleSubscriptionUpdated(
     log.error(`Error in handleSubscriptionUpdated after trying to clear ${customerId} subscription`);
   }
 
-  if (productType == 'business') {
+  if (productType == UserType.Business) {
     const customer = await paymentService.getCustomer(customerId);
     if (customer.deleted) {
       log.error(

--- a/src/webhooks/handleSubscriptionUpdated.ts
+++ b/src/webhooks/handleSubscriptionUpdated.ts
@@ -33,7 +33,7 @@ export default async function handleSubscriptionUpdated(
     log.error(`Error in handleSubscriptionUpdated after trying to clear ${customerId} subscription`);
   }
 
-  if (productType == UserType.Business) {
+  if (productType === UserType.Business) {
     const customer = await paymentService.getCustomer(customerId);
     if (customer.deleted) {
       log.error(

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -5,11 +5,11 @@ import { StorageService } from '../services/StorageService';
 import { UsersService } from '../services/UsersService';
 import handleSubscriptionCanceled from './handleSubscriptionCanceled';
 import handleSubscriptionUpdated from './handleSubscriptionUpdated';
-import handlePaymentMethodAttached from './handlePaymentMethodAttached';
 import { PaymentService } from '../services/PaymentService';
 import handleCheckoutSessionCompleted from './handleCheckoutSessionCompleted';
 import CacheService from '../services/CacheService';
 import handleLifetimeRefunded from './handleLifetimeRefunded';
+import handleSetupIntentSucceded from './handleSetupIntentSucceded';
 
 export default function (
   stripe: Stripe,
@@ -58,18 +58,11 @@ export default function (
             usersService,
             event.data.object as Stripe.Subscription,
             cacheService,
+            paymentService,
             fastify.log,
             config,
           );
           break;
-        case 'payment_method.attached':
-          await handlePaymentMethodAttached(
-            paymentService,
-            (event.data.object as Stripe.PaymentMethod).customer as string,
-            (event.data.object as Stripe.PaymentMethod).id,
-          );
-          break;
-
         case 'checkout.session.completed':
           await handleCheckoutSessionCompleted(
             event.data.object as Stripe.Checkout.Session,
@@ -79,6 +72,12 @@ export default function (
             fastify.log,
             cacheService,
             config,
+          );
+          break;
+        case 'setup_intent.succeeded':
+          await handleSetupIntentSucceded(
+            event.data.object as Stripe.SetupIntent,
+            paymentService,
           );
           break;
         case 'checkout.session.async_payment_succeeded':


### PR DESCRIPTION
## Updates
- Add/Update webhooks to update the payment method according to the `userType` (`individual`, `business`)
- Modify `setup-intent` to add the `metadata` field. From the frontend, they need to send the appropriate `userType` to handle the `setup_intent.succeeded` event and update the appropriate subscription.
- Update the workspace storage if the `userType` is `business`

## Related to
- SDK : https://github.com/internxt/sdk/pull/216