### PR TITLE
[PB-2222]: feat/request-subscriptions-for-business

### DIFF
--- a/src/core/users/MongoDBProductsRepository.ts
+++ b/src/core/users/MongoDBProductsRepository.ts
@@ -1,0 +1,18 @@
+import { Collection, MongoClient } from 'mongodb';
+
+import { Product, ProductsRepository } from './ProductsRepository';
+import { UserType } from './User';
+
+export class MongoDBProductsRepository implements ProductsRepository {
+  private readonly collection: Collection<Product>;
+
+  constructor(mongo: MongoClient) {
+    this.collection = mongo.db('payments').collection<Product>('products');
+  }
+
+  async findByType(type: UserType): Promise<Product[]> {
+    const products = await this.collection.find({ userType: type }).toArray();
+
+    return products;
+  }
+}

--- a/src/core/users/ProductsRepository.ts
+++ b/src/core/users/ProductsRepository.ts
@@ -1,0 +1,10 @@
+import { UserType } from './User';
+
+export interface Product {
+  paymentGatewayId: string;
+  userType: UserType
+}
+
+export interface ProductsRepository {
+  findByType(type: UserType): Promise<Product[]>
+}

--- a/src/core/users/User.ts
+++ b/src/core/users/User.ts
@@ -5,6 +5,11 @@ export interface User {
   lifetime?: boolean;
 }
 
+export enum UserType {
+  Individual = 'individual',
+  Business = 'business'
+}
+
 export type UserSubscription =
   | { type: 'free' | 'lifetime' }
   | {
@@ -16,4 +21,5 @@ export type UserSubscription =
       nextPayment: number;
       priceId: string;
       planId?: string;
+      userType?: UserType
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,8 @@ import { CouponsRepository } from './core/coupons/CouponsRepository';
 import { MongoDBCouponsRepository } from './core/coupons/MongoDBCouponsRepository';
 import { UsersCouponsRepository } from './core/coupons/UsersCouponsRepository';
 import { MongoDBUsersCouponsRepository } from './core/coupons/MongoDBUsersCouponsRepository';
+import { ProductsRepository } from './core/users/ProductsRepository';
+import { MongoDBProductsRepository } from './core/users/MongoDBProductsRepository';
 
 const start = async (): Promise<FastifyInstance> => {
   const mongoClient = await new MongoClient(envVariablesConfig.MONGO_URI).connect();
@@ -30,9 +32,10 @@ const start = async (): Promise<FastifyInstance> => {
   const displayBillingRepository: DisplayBillingRepository = new MongoDBDisplayBillingRepository(mongoClient);
   const couponsRepository: CouponsRepository = new MongoDBCouponsRepository(mongoClient);
   const usersCouponsRepository: UsersCouponsRepository = new MongoDBUsersCouponsRepository(mongoClient);
+  const productsRepository: ProductsRepository = new MongoDBProductsRepository(mongoClient);
 
   const stripe = new Stripe(envVariablesConfig.STRIPE_SECRET_KEY, { apiVersion: '2022-11-15' });
-  const paymentService = new PaymentService(stripe);
+  const paymentService = new PaymentService(stripe, productsRepository);
   const storageService = new StorageService(envVariablesConfig, axios);
   const usersService = new UsersService(
     usersRepository, 


### PR DESCRIPTION
### Changes
- Capability to list for business subscriptions
- Capability to dynamically add new products as business or individual types (via database)

### How to use
`GET /subscriptions?userType={'individual'/'business'}`

- When the `userType`:
  - is not provided or equals 'individual', the behavior is the already existent one.
  - equals 'business', the API will match what the new collection 'products' has with what Stripe says. The match is established using the payments gateway product ID (in this case Stripe). Therefore, for this to work, we need to add a document for each product we have, establishing the `userType` and the product ID, so when listing subscriptions, the match happens.


### What's missing?
- Cache business subscriptions as we do with the individual ones
- Integrate the new dynamic system with individual subscriptions